### PR TITLE
Upgrade PHP image to support Laravel 11 and fix Mailhog platform mismatch

### DIFF
--- a/Dockerfiles/app.Dockerfile
+++ b/Dockerfiles/app.Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.2.5-fpm-alpine3.17
+FROM php:8.3.7-fpm-alpine3.19
 ARG UID
 RUN apk --update add shadow
 RUN usermod -u $UID www-data && groupmod -g $UID www-data

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,7 @@ services:
    - $ADMINER_PORT:8080
  mailhog:
   image: mailhog/mailhog:v1.0.1
+  platform: linux/amd64
   ports:
    - $MAILHOG_SMTP_PORT:1025
    - $MAILHOG_UI_PORT:8025


### PR DESCRIPTION
Changes to be committed:

modified:   Dockerfiles/app.Dockerfile

      php:8.2.5-fpm-alpine3.17 -> php:8.3.7-fpm-alpine3.19
      Upgrades the php image to a version compatible with Laravel 11.

modified:   docker-compose.yml

      This change addresses a warning that appears specifically when running Docker on macOS.

      "! mailhog The requested image's platform (linux/amd64) does not match the detected host platform (linux/arm64/v8) and no specific platform was requested".

      By adding the line "platform: linux/amd64" we ensure that Docker tries to run the MailHog image on the amd64 architecture, which is commonly used on Linux-based systems. This specification may not be necessary when using a Linux-based host system, as Docker usually automatically selects the correct platform, so including this line adds clarity and consistency to the Docker configuration.